### PR TITLE
POC mover charlas separadas de ponentes.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,9 +11,9 @@ params:
   Name: "tabular"
   Extraname: "Conf"
   Description: "On the edge of datascience"
-  Date: "30 de Enero 2021"
+  Date: "30 de enero 2021"
   #Price: "Only $100" # If your event is free, just comment this line
-  #Twitter: "@prueba"
+  #Twitter: "@TabularConf"
   Venue: "2020"
   #Address: "Boulevard Kukulcan, 30"
   City:  "Online"
@@ -180,3 +180,9 @@ params:
         title: "TBD"
         description: "TBD "
         time:
+
+  Talks:
+    - title: "whatever"
+      author: "something"
+      abstract: "whatever2"
+      time: ""

--- a/themes/hugo-conference/layouts/partials/schedule.html
+++ b/themes/hugo-conference/layouts/partials/schedule.html
@@ -5,36 +5,28 @@
   <table>
     <thead>
       <tr>
-        <th class="schedule-time">Tiempo</th>
+        <th class="schedule-time">Hora</th>
         <th class="schedule-slot">Título</th>
-        <th class="schedule-description">Descripción</th>
+        <th class="schedule-description">Abstract</th>
       </tr>
     </thead>
     <tbody>
-      {{ range $slot := .schedule }}
-        {{ if ne .presentation nil }}
-          <tr>
-            <td class="schedule-time">{{ .presentation.time }}</td>
-            <td class="schedule-slot">
-            {{ with .photo }}
-              <!--<span class="speaker-photo">
-                <img class="photo" src="{{ . }}" alt="{{ $slot.name }}">
-              </span>-->
-            {{ end }}
+      {{ range $slot := .talks }}
+        <tr>
+          <td class="schedule-time">{{ .time }}</td>
+          <td class="schedule-slot">
+          {{ with .photo }}
+            <!--<span class="speaker-photo">
+              <img class="photo" src="{{ . }}" alt="{{ $slot.name }}">
+            </span>-->
+          {{ end }}
 
-              {{ .presentation.title }} ({{ .name }})
-              <!--<span class="speakers-company">{{ .company }}</span>-->
-            </td>
-            
-            <td class="schedule-description">{{ .presentation.description }}</td>
-          </tr>
-        {{ else }}
-          <tr class="schedule-other">
-            <td class="schedule-time">{{ .time }}</td>
-            <td class="schedule-slot">{{ .name }}</td>
-            <td class="schedule-description">-</td>
-          </tr>
-        {{ end }}
+            {{ .title }} ({{ .author }})
+            <!--<span class="speakers-company">{{ .company }}</span>-->
+          </td>
+          
+          <td class="schedule-description">{{ .abstract }}</td>
+        </tr>
       {{ end }}
     </tbody>
   </table>


### PR DESCRIPTION
He visto que en la charla de Juan Calderón y Javi Fernández hay un problema, porque el template asume que cada charla la da solamente un ponente. Propongo separar las estructuras de datos de charlas de los ponentes para evitar el problema. Sería copiar y pegar unas cuantas cosas pero poco más.